### PR TITLE
Changes to samples to run on ILGPU 0.4.0-beta

### DIFF
--- a/Src/AdvancedAtomics/AdvancedAtomics.csproj
+++ b/Src/AdvancedAtomics/AdvancedAtomics.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/AdvancedViews/AdvancedViews.csproj
+++ b/Src/AdvancedViews/AdvancedViews.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/AdvancedViews/Program.cs
+++ b/Src/AdvancedViews/Program.cs
@@ -64,7 +64,7 @@ namespace AdvancedViews
             {
                 var baseView = view.GetVariableView(0);
                 var counterView = baseView.GetSubView<int>(ComposedStructure.ElementCounterOffset);
-                Atomic.Add(counterView, 1);
+                Atomic.Add(ref counterView.Value, 1);
             }
         }
 
@@ -83,7 +83,7 @@ namespace AdvancedViews
                     using (var accelerator = Accelerator.Create(context, acceleratorId))
                     {
                         Console.WriteLine($"Performing operations on {accelerator}");
-                        var kernel = accelerator.LoadAutoGroupedStreamKernel<
+                        var kernel = accelerator.LoadAutoGroupedKernel<
                             Index, ArrayView<int>, ArrayView<ComposedStructure>, int>(MyKernel);
 
                         using (var elementsBuffer = accelerator.Allocate<int>(1024))
@@ -93,11 +93,11 @@ namespace AdvancedViews
                                 elementsBuffer.MemSetToZero();
                                 composedStructBuffer.MemSetToZero();
 
-                                kernel(elementsBuffer.Length, elementsBuffer.View, composedStructBuffer.View, 0);
+                                kernel(accelerator.DefaultStream, elementsBuffer.Length, elementsBuffer.View, composedStructBuffer.View, 0);
 
                                 accelerator.Synchronize();
 
-                                var composedResult = composedStructBuffer[0];
+                                var composedResult = composedStructBuffer.View[0];
                                 Console.WriteLine("Composed.SomeElement = " + composedResult.SomeElement);
                                 Console.WriteLine("Composed.SomeOtherElement = " + composedResult.SomeOtherElement);
                                 Console.WriteLine("Composed.ElementCounter = " + composedResult.ElementCounter);

--- a/Src/DeviceInfo/DeviceInfo.csproj
+++ b/Src/DeviceInfo/DeviceInfo.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/DeviceInfo/Program.cs
+++ b/Src/DeviceInfo/Program.cs
@@ -60,7 +60,7 @@ namespace DeviceInfo
                 // Accelerators can also be created manually with custom settings.
                 // The following code snippet creates a CPU accelerator with 4 threads
                 // and a warp size of 2 threads per warp and the highest thread priority.
-                using (var accelerator = new CPUAccelerator(context, 2, 2, ThreadPriority.Highest))
+                using (var accelerator = new CPUAccelerator(context, 4, ThreadPriority.Highest))
                 {
                     PrintAcceleratorInfo(accelerator);
                 }

--- a/Src/Empty/Empty.csproj
+++ b/Src/Empty/Empty.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/ExplicitlyGroupedKernels/ExplicitlyGroupedKernels.csproj
+++ b/Src/ExplicitlyGroupedKernels/ExplicitlyGroupedKernels.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/ExplicitlyGroupedKernels/Program.cs
+++ b/Src/ExplicitlyGroupedKernels/Program.cs
@@ -171,7 +171,7 @@ namespace ExplicitlyGroupedKernels
                         using (var dataSource = accelerator.Allocate<int>(data.Length))
                         {
                             // Initialize data source
-                            dataSource.CopyFrom(data, 0, 0, data.Length);
+                            dataSource.CopyFrom(accelerator.DefaultStream, data, 0, 0, data.Length);
 
                             using (var dataTarget = accelerator.Allocate<int>(data.Length))
                             {
@@ -180,13 +180,13 @@ namespace ExplicitlyGroupedKernels
                                 {
                                     dataTarget.MemSetToZero();
 
-                                    var groupedKernel = accelerator.LoadStreamKernel<GroupedIndex, ArrayView<int>, int>(GroupedKernel);
-                                    groupedKernel(launchDimension, dataTarget.View, 64);
+                                    var groupedKernel = accelerator.LoadKernel<GroupedIndex, ArrayView<int>, int>(GroupedKernel);
+                                    groupedKernel(accelerator.DefaultStream, launchDimension, dataTarget.View, 64);
 
                                     accelerator.Synchronize();
 
                                     Console.WriteLine("Default grouped kernel");
-                                    var target = dataTarget.GetAsArray();
+                                    var target = dataTarget.GetAsArray(accelerator.DefaultStream);
                                     for (int i = 0, e = target.Length; i < e; ++i)
                                         Console.WriteLine($"Data[{i}] = {target[i]}");
                                 }
@@ -195,13 +195,13 @@ namespace ExplicitlyGroupedKernels
                                 {
                                     dataTarget.MemSetToZero();
 
-                                    var groupedKernel = accelerator.LoadStreamKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelBarrier);
-                                    groupedKernel(launchDimension, dataSource, dataTarget.View, 64);
+                                    var groupedKernel = accelerator.LoadKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelBarrier);
+                                    groupedKernel(accelerator.DefaultStream, launchDimension, dataSource, dataTarget.View, 64);
 
                                     accelerator.Synchronize();
 
                                     Console.WriteLine("Grouped-barrier kernel");
-                                    var target = dataTarget.GetAsArray();
+                                    var target = dataTarget.GetAsArray(accelerator.DefaultStream);
                                     for (int i = 0, e = target.Length; i < e; ++i)
                                         Console.WriteLine($"Data[{i}] = {target[i]}");
                                 }
@@ -210,13 +210,13 @@ namespace ExplicitlyGroupedKernels
                                 {
                                     dataTarget.MemSetToZero();
 
-                                    var groupedKernel = accelerator.LoadStreamKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelAndBarrier);
-                                    groupedKernel(launchDimension, dataSource, dataTarget.View, 0);
+                                    var groupedKernel = accelerator.LoadKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelAndBarrier);
+                                    groupedKernel(accelerator.DefaultStream, launchDimension, dataSource, dataTarget.View, 0);
 
                                     accelerator.Synchronize();
 
                                     Console.WriteLine("Grouped-and-barrier kernel");
-                                    var target = dataTarget.GetAsArray();
+                                    var target = dataTarget.GetAsArray(accelerator.DefaultStream);
                                     for (int i = 0, e = target.Length; i < e; ++i)
                                         Console.WriteLine($"Data[{i}] = {target[i]}");
                                 }
@@ -225,13 +225,13 @@ namespace ExplicitlyGroupedKernels
                                 {
                                     dataTarget.MemSetToZero();
 
-                                    var groupedKernel = accelerator.LoadStreamKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelOrBarrier);
-                                    groupedKernel(launchDimension, dataSource, dataTarget.View, 64);
+                                    var groupedKernel = accelerator.LoadKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelOrBarrier);
+                                    groupedKernel(accelerator.DefaultStream, launchDimension, dataSource, dataTarget.View, 64);
 
                                     accelerator.Synchronize();
 
                                     Console.WriteLine("Grouped-or-barrier kernel");
-                                    var target = dataTarget.GetAsArray();
+                                    var target = dataTarget.GetAsArray(accelerator.DefaultStream);
                                     for (int i = 0, e = target.Length; i < e; ++i)
                                         Console.WriteLine($"Data[{i}] = {target[i]}");
                                 }
@@ -240,13 +240,13 @@ namespace ExplicitlyGroupedKernels
                                 {
                                     dataTarget.MemSetToZero();
 
-                                    var groupedKernel = accelerator.LoadStreamKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelPopCountBarrier);
-                                    groupedKernel(launchDimension, dataSource, dataTarget.View, 0);
+                                    var groupedKernel = accelerator.LoadKernel<GroupedIndex, ArrayView<int>, ArrayView<int>, int>(GroupedKernelPopCountBarrier);
+                                    groupedKernel(accelerator.DefaultStream, launchDimension, dataSource, dataTarget.View, 0);
 
                                     accelerator.Synchronize();
 
                                     Console.WriteLine("Grouped-popcount-barrier kernel");
-                                    var target = dataTarget.GetAsArray();
+                                    var target = dataTarget.GetAsArray(accelerator.DefaultStream);
                                     for (int i = 0, e = target.Length; i < e; ++i)
                                         Console.WriteLine($"Data[{i}] = {target[i]}");
                                 }

--- a/Src/ImplicitlyGroupedKernels/ImplicitlyGroupedKernels.csproj
+++ b/Src/ImplicitlyGroupedKernels/ImplicitlyGroupedKernels.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/IndexImplementation/IndexImplementation.csproj
+++ b/Src/IndexImplementation/IndexImplementation.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/IndexImplementation/Program.cs
+++ b/Src/IndexImplementation/Program.cs
@@ -316,6 +316,7 @@ namespace IndexImplementation
             {
                 // Copy to accelerator
                 buffer.CopyFrom(
+                    accelerator.DefaultStream,
                     data,                      // data source
                     0,                         // source index in the scope of the data source
                     new MyIndex4(2, 0, 0, 0),  // target index in the scope of the buffer
@@ -323,6 +324,7 @@ namespace IndexImplementation
 
                 // Copy from accelerator
                 buffer.CopyTo(
+                    accelerator.DefaultStream,
                     targetData,                // data target
                     new MyIndex4(2, 0, 0, 0),  // target index in the scope of the buffer
                     0,                         // target index in the scope of the data target
@@ -389,10 +391,10 @@ namespace IndexImplementation
                         AllocND(accelerator, (idx, dimension) => idx.ComputeLinearIndex(dimension));
                         AllocND(accelerator, (idx, dimension) => (long)idx.ComputeLinearIndex(dimension));
 
-                        var kernel = accelerator.LoadAutoGroupedStreamKernel<Index, ArrayView<int, MyIndex4>>(MyKernelND);
+                        var kernel = accelerator.LoadAutoGroupedKernel<Index, ArrayView<int, MyIndex4>>(MyKernelND);
                         using (var buffer = accelerator.Allocate<int, MyIndex4>(Dimension))
                         {
-                            kernel(Dimension.Size, buffer.View);
+                            kernel(accelerator.DefaultStream, Dimension.Size, buffer.View);
 
                             accelerator.Synchronize();
                         }

--- a/Src/LowLevelKernelCompilation/LowLevelKernelCompilation.csproj
+++ b/Src/LowLevelKernelCompilation/LowLevelKernelCompilation.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/Mandelbrot/Mandelbrot.csproj
+++ b/Src/Mandelbrot/Mandelbrot.csproj
@@ -41,10 +41,7 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Src/SimpleAlloc/Program.cs
+++ b/Src/SimpleAlloc/Program.cs
@@ -53,6 +53,7 @@ namespace SimpleAlloc
             {
                 // Copy to accelerator
                 buffer.CopyFrom(
+                    accelerator.DefaultStream,
                     data,         // data source
                     0,            // source index in the scope of the data source
                     32,           // target index in the scope of the buffer
@@ -60,6 +61,7 @@ namespace SimpleAlloc
 
                 // Copy from accelerator
                 buffer.CopyTo(
+                    accelerator.DefaultStream,
                     targetData,   // data target
                     32,           // source index in the scope of the buffer
                     0,            // target index in the scope of the data target
@@ -95,6 +97,7 @@ namespace SimpleAlloc
             {
                 // Copy to accelerator
                 buffer.CopyFrom(
+                    accelerator.DefaultStream,
                     data,                                             // data source
                     new Index2(),                                     // source index in the scope of the data source
                     new Index2(32, 0),                                // target index in the scope of the buffer
@@ -102,6 +105,7 @@ namespace SimpleAlloc
 
                 // Copy from accelerator
                 buffer.CopyTo(
+                    accelerator.DefaultStream,
                     targetData,                                       // data target
                     new Index2(32, 0),                                // source index in the scope of the data source
                     new Index2(),                                     // target index in the scope of the buffer
@@ -141,6 +145,7 @@ namespace SimpleAlloc
             {
                 // Copy to accelerator
                 buffer.CopyFrom(
+                    accelerator.DefaultStream,
                     data,                                                               // data source
                     new Index3(),                                                       // source index in the scope of the data source
                     new Index3(32, 0, 0),                                               // target index in the scope of the buffer
@@ -148,6 +153,7 @@ namespace SimpleAlloc
 
                 // Copy from accelerator
                 buffer.CopyTo(
+                    accelerator.DefaultStream,
                     targetData,                                                         // data target
                     new Index3(32, 0, 0),                                               // target index in the scope of the buffer
                     new Index3(),                                                       // source index in the scope of the data source
@@ -180,18 +186,18 @@ namespace SimpleAlloc
             using (var buffer = accelerator.Allocate<int>(1))
             {
                 // Copy int(42) to the buffer at index 0.
-                buffer[0] = 42;
+                buffer.View[0] = 42;
                 // You can also use:
-                buffer.CopyFrom(42, 0);
+                buffer.CopyFrom(accelerator.DefaultStream, 42, 0);
 
                 // Read value of buffer at index 0.
-                Console.WriteLine("Resolved value: " + buffer[0]);
+                Console.WriteLine("Resolved value: " + buffer.View[0]);
 
                 // You can also use:
                 int bufferValue;
-                buffer.CopyTo(out bufferValue, 0);
+                buffer.CopyTo(accelerator.DefaultStream, out bufferValue, 0);
 
-                Console.WriteLine("Resolved value 2: " + buffer[0]);
+                Console.WriteLine("Resolved value 2: " + buffer.View[0]);
 
                 // Note that accessing data this way from the CPU is only possible on the buffer, but not on its views:
                 var view = buffer.View;

--- a/Src/SimpleAlloc/SimpleAlloc.csproj
+++ b/Src/SimpleAlloc/SimpleAlloc.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/SimpleAtomics/SimpleAtomics.csproj
+++ b/Src/SimpleAtomics/SimpleAtomics.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/SimpleConstants/SimpleConstants.csproj
+++ b/Src/SimpleConstants/SimpleConstants.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/SimpleKernel/Program.cs
+++ b/Src/SimpleKernel/Program.cs
@@ -64,20 +64,20 @@ namespace SimpleKernel
                         // parameter. In this case the corresponding call will look like this:
                         // var kernel = accelerator.LoadautoGroupedKernel<Index, ArrayView<int>, int>(MyKernel);
                         // For more detail refer to the ImplicitlyGroupedKernels or ExplicitlyGroupedKernels sample.
-                        var kernel = accelerator.LoadAutoGroupedStreamKernel<
+                        var kernel = accelerator.LoadAutoGroupedKernel<
                             Index, ArrayView<int>, int>(MyKernel);
 
                         using (var buffer = accelerator.Allocate<int>(1024))
                         {
                             // Launch buffer.Length many threads and pass a view to buffer
                             // Note that the kernel launch does not involve any boxing
-                            kernel(buffer.Length, buffer.View, 42);
+                            kernel(accelerator.DefaultStream, buffer.Length, buffer.View, 42);
 
                             // Wait for the kernel to finish...
                             accelerator.Synchronize();
 
                             // Resolve and verify data
-                            var data = buffer.GetAsArray();
+                            var data = buffer.GetAsArray(accelerator.DefaultStream);
                             for (int i = 0, e = data.Length; i < e; ++i)
                             {
                                 if (data[i] != 42 + i)

--- a/Src/SimpleKernel/SimpleKernel.csproj
+++ b/Src/SimpleKernel/SimpleKernel.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/SimpleMath/SimpleMath.csproj
+++ b/Src/SimpleMath/SimpleMath.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/SimpleStructures/Program.cs
+++ b/Src/SimpleStructures/Program.cs
@@ -71,11 +71,11 @@ namespace SimpleStructures
                     using (var accelerator = Accelerator.Create(context, acceleratorId))
                     {
                         Console.WriteLine($"Performing operations on {accelerator}");
-                        var kernel = accelerator.LoadAutoGroupedStreamKernel<Index, ArrayView<CustomDataType>>(MyKernel);
+                        var kernel = accelerator.LoadAutoGroupedKernel<Index, ArrayView<CustomDataType>>(MyKernel);
                         using (var buffer = accelerator.Allocate<CustomDataType>(1024))
                         {
                             // Launch buffer.Length many threads and pass a view to buffer
-                            kernel(buffer.Length, buffer.View);
+                            kernel(accelerator.DefaultStream, buffer.Length, buffer.View);
 
                             // Wait for the kernel to finish...
                             accelerator.Synchronize();

--- a/Src/SimpleStructures/SimpleStructures.csproj
+++ b/Src/SimpleStructures/SimpleStructures.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>

--- a/Src/SimpleViews/Program.cs
+++ b/Src/SimpleViews/Program.cs
@@ -64,10 +64,10 @@ namespace SimpleViews
             // Creates a variable view that points to the last accessible element
             // of the provided view
             var variableView = view.GetVariableView(view.Length - 1);
-            variableView.Store(13);
+            variableView.Value = 13;
 
             // Note that view.Load(idx) is an alias for view[idx]
-            Debug.Assert(variableView.Load() == view.Load(view.Length - 1));
+            Debug.Assert(variableView.Value == view[view.Length - 1]);
         }
 
         static void UnsafeVariableViewAccess(ArrayView<int> view)
@@ -80,9 +80,9 @@ namespace SimpleViews
             // The primary use case for this functionality are direct accesses
             // to structure members.
             var subView = variableView.GetSubView<short>(sizeof(short));
-            subView.Store(short.MaxValue);
+            subView.Value = short.MaxValue;
 
-            Debug.Assert(variableView.Load() == short.MaxValue << 16);
+            Debug.Assert(variableView.Value == short.MaxValue << 16);
         }
 
         /// <summary>

--- a/Src/SimpleViews/SimpleViews.csproj
+++ b/Src/SimpleViews/SimpleViews.csproj
@@ -1,12 +1,9 @@
 ﻿<Project Sdk="Microsoft.Net.SDK">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net47;netcoreapp2.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ILGPU" Version="0.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.4.0" />
-    <PackageReference Include="System.Reflection.Metadata" Version="1.5.0" />
-    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.4.0" />
+    <PackageReference Include="ILGPU" Version="0.4.0-beta" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is mostly legwork to play with 0.4.0-beta version, but it was too difficult to me correctly move all code.
The samples not fully moved, and I just want to make this PR as starting point for discussion. Maybe some of my findings could be useful for other people who will migrate their code.

## Missing samples
- WarpShuffle
- SharedMemory
- All ILGPU.Lightning samples

## ILGPU changes

1. `Atomic.Sub` missing. Not sure, but I believe that I should replace with `Atomic.Add(… , -value)`
2. `dataView.GetVariableView(3)` replaced with `ref dataView.GetVariableView(3).Value`
3. `buffer.GetAsArray()` replaced with `buffer.GetAsArray(accelerator.DefaultStream)`
4. `accelerator.LoadAutoGroupedStreamKernel` should be replaced with `accelerator.LoadAutoGroupedKernel` and then pass `accelerator.DefaultStream` as additional first argument to created kernel.
5. `CompileUnitFlags` looks like replaced with `IRContextFlags` and these parameters now should be passed during creation of the `Context`, and not during call to `Accelerator.Create`
6. `GPUMath`  replaced with `XMath`
7. `variableView.Store(value)` replaced with `variableView.Value = value`
8. `buffer.CopyFrom` now require passing additional parameter `accelerator.DefaultStream`
9. `Warp.Reduce` removed, and no alternative given as far, I aware. WarpShuffle sample I could not port.
10. `Accelerator.LoadSharedMemoryStreamKernel1` not available, or I do not find proper replacement
11. `SharedMemory` seems to be not available too

## ILGPU.Lighting changes
ILGPU.Lightning for 0.4.0-beta not available yet