### PR TITLE
Casing corrected for SDK name in project files. "Microsoft.NET.Sdk" i…

### DIFF
--- a/Src/AdjustableSharedMemory/AdjustableSharedMemory.csproj
+++ b/Src/AdjustableSharedMemory/AdjustableSharedMemory.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AdvancedAtomics/AdvancedAtomics.csproj
+++ b/Src/AdvancedAtomics/AdvancedAtomics.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AdvancedViews/AdvancedViews.csproj
+++ b/Src/AdvancedViews/AdvancedViews.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsCuBlas/AlgorithmsCuBlas.csproj
+++ b/Src/AlgorithmsCuBlas/AlgorithmsCuBlas.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsGroups/AlgorithmsGroups.csproj
+++ b/Src/AlgorithmsGroups/AlgorithmsGroups.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsInitialize/AlgorithmsInitialize.csproj
+++ b/Src/AlgorithmsInitialize/AlgorithmsInitialize.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsMath/AlgorithmsMath.csproj
+++ b/Src/AlgorithmsMath/AlgorithmsMath.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsRadixSort/AlgorithmsRadixSort.csproj
+++ b/Src/AlgorithmsRadixSort/AlgorithmsRadixSort.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsReduce/AlgorithmsReduce.csproj
+++ b/Src/AlgorithmsReduce/AlgorithmsReduce.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsScan/AlgorithmsScan.csproj
+++ b/Src/AlgorithmsScan/AlgorithmsScan.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsSequence/AlgorithmsSequence.csproj
+++ b/Src/AlgorithmsSequence/AlgorithmsSequence.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsTransform/AlgorithmsTransform.csproj
+++ b/Src/AlgorithmsTransform/AlgorithmsTransform.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/AlgorithmsWarps/AlgorithmsWarps.csproj
+++ b/Src/AlgorithmsWarps/AlgorithmsWarps.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/CustomIntrinsics/CustomIntrinsics.csproj
+++ b/Src/CustomIntrinsics/CustomIntrinsics.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/DeviceInfo/DeviceInfo.csproj
+++ b/Src/DeviceInfo/DeviceInfo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/DynamicSharedMemory/DynamicSharedMemory.csproj
+++ b/Src/DynamicSharedMemory/DynamicSharedMemory.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/Empty/Empty.csproj
+++ b/Src/Empty/Empty.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/EmptyAlgorithms/EmptyAlgorithms.csproj
+++ b/Src/EmptyAlgorithms/EmptyAlgorithms.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/ExplicitlyGroupedKernels/ExplicitlyGroupedKernels.csproj
+++ b/Src/ExplicitlyGroupedKernels/ExplicitlyGroupedKernels.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/GenericKernel/GenericKernel.csproj
+++ b/Src/GenericKernel/GenericKernel.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/GroupGridIndices/GroupGridIndices.csproj
+++ b/Src/GroupGridIndices/GroupGridIndices.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/ImplicitlyGroupedKernels/ImplicitlyGroupedKernels.csproj
+++ b/Src/ImplicitlyGroupedKernels/ImplicitlyGroupedKernels.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/IndexImplementation/IndexImplementation.csproj
+++ b/Src/IndexImplementation/IndexImplementation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/LowLevelKernelCompilation/LowLevelKernelCompilation.csproj
+++ b/Src/LowLevelKernelCompilation/LowLevelKernelCompilation.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/PinnedMemoryCopy/PinnedMemoryCopy.csproj
+++ b/Src/PinnedMemoryCopy/PinnedMemoryCopy.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SharedMemory/SharedMemory.csproj
+++ b/Src/SharedMemory/SharedMemory.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleAlloc/SimpleAlloc.csproj
+++ b/Src/SimpleAlloc/SimpleAlloc.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleAtomics/SimpleAtomics.csproj
+++ b/Src/SimpleAtomics/SimpleAtomics.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleConstants/SimpleConstants.csproj
+++ b/Src/SimpleConstants/SimpleConstants.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleKernel/SimpleKernel.csproj
+++ b/Src/SimpleKernel/SimpleKernel.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleMath/SimpleMath.csproj
+++ b/Src/SimpleMath/SimpleMath.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleStructures/SimpleStructures.csproj
+++ b/Src/SimpleStructures/SimpleStructures.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SimpleViews/SimpleViews.csproj
+++ b/Src/SimpleViews/SimpleViews.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/SpecializedKernel/SpecializedKernel.csproj
+++ b/Src/SpecializedKernel/SpecializedKernel.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>

--- a/Src/WarpShuffle/WarpShuffle.csproj
+++ b/Src/WarpShuffle/WarpShuffle.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Net.SDK">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net47;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Casing corrected for SDK name in project files. "Microsoft.NET.Sdk" is the official name.
"Microsoft.Net.SDK" leads to build errors on non Windows platforms (Linux), presumably because searching SDK files fails on case sensitive file systems.

